### PR TITLE
V1.20.x

### DIFF
--- a/Early Mod Toolkit 3/EarlyModToolKit.csproj
+++ b/Early Mod Toolkit 3/EarlyModToolKit.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>3.2.0-beta.1</Version>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <TargetFramework>net8</TargetFramework>
   </PropertyGroup>
 

--- a/Early Mod Toolkit 3/EarlyModToolKit.csproj
+++ b/Early Mod Toolkit 3/EarlyModToolKit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>3.2.0-beta.1</Version>
+    <Version>3.2.0-beta.2</Version>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8</TargetFramework>
   </PropertyGroup>

--- a/Early Mod Toolkit 3/EarlyModToolKit.csproj
+++ b/Early Mod Toolkit 3/EarlyModToolKit.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <Target Name="Package" AfterTargets="PostBuildEvent">
-    <ZipDirectory DestinationFile="bin/$(TargetName)-$(Version).zip" SourceDirectory="bin/Debug/net8" Overwrite="true"/>
+    <ZipDirectory DestinationFile="bin/$(TargetName)-$(Version).zip" SourceDirectory="bin/$(Configuration)/$(TargetFramework)" Overwrite="true"/>
   </Target>
 
 </Project>


### PR DESCRIPTION
This contains the changes discussed in Discord.

It should fix the `Unhandled exception. HarmonyLib.HarmonyException: Patching exception in method virtual System.String Vintagestory.Client.Gui.MainMenuInputAPI::get_ClipboardText()` crash at startup on Windows. 

It also contains a tweak to not launch with a console by default in windows.
For diagnostics on windows a console launch can still be achieved by running the dll directly e.g. `dotnet .\EarlyModToolKit.dll`.